### PR TITLE
Fixes for Mix dependencies and  shelltestrunner

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,2 +1,2 @@
 {erl_opts, [debug_info]}.
-{deps, [recon]}.
+{deps, [{recon, ">= 0.0.0"}]}.

--- a/shelltests/epmdless_test/epmdless_test.test
+++ b/shelltests/epmdless_test/epmdless_test.test
@@ -1,20 +1,20 @@
-$ rebar3 release
-> / Release successfully assembled: /
->= 0
+rebar3 release
+>>> / Release successfully assembled: /
+>>>= 0
 
-$ ERL_DIST_PORT=9001 _build/default/rel/epmdless_test/bin/epmdless_test daemon
->= 0
+ERL_DIST_PORT=9001 _build/default/rel/epmdless_test/bin/epmdless_test daemon
+>>>= 0
 
-$ ERL_DIST_PORT=9001 _build/default/rel/epmdless_test/bin/epmdless_test ping
->
+ERL_DIST_PORT=9001 _build/default/rel/epmdless_test/bin/epmdless_test ping
+>>>
 pong
->= 0
+>>>= 0
 
 # fail when a different port is set to ERL_DIST_PORT
-$ ERL_DIST_PORT=9002 _build/default/rel/epmdless_test/bin/epmdless_test ping
->
+ERL_DIST_PORT=9002 _build/default/rel/epmdless_test/bin/epmdless_test ping
+>>>
 Node is not running!
->= 1
+>>>= 1
 
-$ ERL_DIST_PORT=9001 _build/default/rel/epmdless_test/bin/epmdless_test stop
->= 0
+ERL_DIST_PORT=9001 _build/default/rel/epmdless_test/bin/epmdless_test stop
+>>>= 0


### PR DESCRIPTION
There is an error when using Github as dependency in Mix with OTP 24.

```
defp deps do
  [
    {:epmdless, github: "tsloughter/epmdless"}
  ]
end
```

The error is about invalid dependency format as the following.

```
** (Mix) Dependency specified in the wrong format:

    {:recon, nil, [override: true]}

Expected:

    {app, opts} | {app, requirement} | {app, requirement, opts}

Where:

    app :: atom
    requirement :: String.t | Regex.t
    opts :: keyword

If you want to skip the requirement (not recommended), use ">= 0.0.0".
```

Also, I think there are changes to shelltestrunner syntax.
Tested on **shelltest 1.3.5**