### PR TITLE
Fix bad pattern match in `address_please`

### DIFF
--- a/src/epmdless_client.erl
+++ b/src/epmdless_client.erl
@@ -101,12 +101,16 @@ port_please(Name, Host) ->
 	  Success :: {ok, inet:ip_address(), Port, Version}.
 %% @doc Resolves the Host to an IP address of a remote node.
 address_please(Name, Host, AddressFamily) ->
-    {ok, Address} = inet:getaddr(Host, AddressFamily),
-    case port_please(Name, Address) of
-        {port, Port, Version} ->
-            {ok, Address, Port, Version};
-        noport ->
-            {error, noport}
+    case inet:getaddr(Host, AddressFamily) of
+        {ok, Address} ->
+            case port_please(Name, Address) of
+                {port, Port, Version} ->
+                    {ok, Address, Port, Version};
+                noport ->
+                    {error, noport}
+            end;
+        {error, Reason} ->
+            {error, Reason}
     end.
 
 %% @doc Returns the port the local node should listen to when accepting new distribution requests.


### PR DESCRIPTION
This is patch for a bug that my team was running into when we were using `epmdless`.

TLDR when `Node.connect(node)` is called on a node that is having a transient networking issue, the `epmdless_client` (and the underlying `net_kernel` that uses it) will crash. 

The stacktrace shows that this happens because `inet:getaddr` returns `{:error, :nxdomain}` but the current implementation of `address_please` assumes that the response is always of the form `{ok, _}`. The patch adds additional pattern matching for the error case. 

**Validation**: (I've tested that `Node.connect(some_bad_address)` no longer fails, it returns `false` as I'd expect).
